### PR TITLE
Fix typo error that followed linter automatic fix

### DIFF
--- a/lib/vault-client.js
+++ b/lib/vault-client.js
@@ -96,7 +96,7 @@ const authMethods = {
       headers: {
         'Content-type': 'application/json'
       },
-      body: JSON.stringify({ roleId, secretId })
+      body: JSON.stringify({ role_id: roleId, secret_id: secretId })
     })
       .then(data => data.json())
       .then((data) => data.auth.client_token);

--- a/tests/vault-client.spec.js
+++ b/tests/vault-client.spec.js
@@ -105,7 +105,7 @@ describe('Vault Client', () => {
           headers: {
             'Content-type': 'application/json'
           },
-          body: JSON.stringify(credentials)
+          body: JSON.stringify({ role_id: credentials.roleId, secret_id: credentials.secretId })
         });
         expect(client.token).toBe('token');
       });


### PR DESCRIPTION
@gkampitakis ,

I am sorry for this error, I first wrote the approle authentication options with snake case and I did not tested after I fixed the lint errors which requires camel case for secretId and role_id.

In case you want to test it, there is this link https://codersociety.com/blog/articles/hashicorp-vault-node that explains the vault configuration and here is the code I use to test it:

```
import fastify, { FastifyInstance, FastifyListenOptions } from "fastify";
import { FastifySecretsVaultOptions, fastifySecretsVault} from 'fastify-secrets-vault';

const port: number = +(process.env.HTTP_PORT || 3000);
const server: FastifyInstance = fastify();
const path = 'secret/data/mongo/webapp';

server.register(fastifySecretsVault, {
  secrets: {
    db_name: {
      path,
      key: 'db_name'
    },
    username: {
      path,
      key: 'username'
    },
    password: {
      path,
      key: 'password'
    }
  },
  vaultOptions: {
    endpoint: 'http://vault:8200',
    authentication: {
      method: 'approle',
      credentials: {
        roleId: process.env.VAULT_ROLE_ID || '',
        secretId: process.env.VAULT_SECRET_ID || ''
      }
    }
  }});

server.register((fastify, opts, done) => {
  console.log('ahahahahaah', fastify.secrets);
  done();
});

const run = async () => {
  try {
    const options: FastifyListenOptions = {
      port,
      host: "0.0.0.0",
    };
    await server.listen(options);
    console.log(`Server listening at ${options.host}: ${options.port}`);
  } catch (error) {
    console.error(error);
    process.exit(1);
  }
};

run();
```